### PR TITLE
Change get_bucket call to use Bucket object...

### DIFF
--- a/s3yum/s3yum_cli.py
+++ b/s3yum/s3yum_cli.py
@@ -149,7 +149,7 @@ def parse_args(context, argv):
 
     parser.add_option(
         "-p", "--path",
-        help='Root path of the repo (RPM destination) relative to bucket',
+        help='Root path of the repo (RPM destination) relative to '',
         type='string', default='dev')
 
     parser.add_option(
@@ -319,7 +319,7 @@ def connect_to_bucket(context):
             else:
                 conn = boto.connect_s3()
 
-        bucket = conn.get_bucket(context.opts.bucket)
+        bucket = boto.s3.bucket.Bucket(conn, context.opts.bucket)
         context.s3_conn = conn
         context.s3_bucket = bucket
     except boto.exception.BotoServerError as ex:


### PR DESCRIPTION
Where user doesn't have full ListBucket permissions on a bucket, such as in a shared environment where they are writing to a subfolder under the main bucket, this fails with a 403 even though they have permissions to write to the subfolder.

See: https://stackoverflow.com/questions/42717551/boto-s3-bucket-versus-get-bucket